### PR TITLE
Set clipmask to the right value based on interference (fixes #19)

### DIFF
--- a/src/qagame/qagame.c
+++ b/src/qagame/qagame.c
@@ -152,3 +152,16 @@ void target_laser_think_Hook(gentity_t *self)
     trap_LinkEntity(self);
     self->nextthink = levelTime + FRAMETIME;
 }
+
+void ClientSpawnEntSetStuff_Hook(gentity_t *ent)
+{
+    int interferenceOff;
+
+    // When fixing this in DeFRaG, it should be straightforward.
+    // Just set ent->clipmask to the right thing in ClientSpawn or
+    // one of the things it calls maybe, like the following.
+    ClientSpawnEntSetStuff(ent);
+    interferenceOff = trap_Cvar_VariableIntegerValue("df_mp_interferenceOff");
+    if (interferenceOff & 1)
+        ent->clipmask &= ~CONTENTS_BODY;
+}

--- a/src/qagame/qagame.h
+++ b/src/qagame/qagame.h
@@ -22,5 +22,6 @@ typedef struct
 
 extern int levelTime; // should be level.time (too lazy to verify struct layout hasn't changed)
 extern timerInfo_t timers[MAX_CLIENTS];
+extern void ClientSpawnEntSetStuff(gentity_t *);
 extern int get_cheats_enabled(void);
 extern void placeplayer_teleport(gentity_t *, vec3_t, vec3_t, vec3_t);

--- a/src/qagame/qagame.py
+++ b/src/qagame/qagame.py
@@ -11,6 +11,7 @@ symbols = {
     "atof": 0x5d6d,
     "atoi": 0x5efd,
     "ClientCommand": 0x1f3c3,
+    "ClientSpawnEntSetStuff": 0x2722,
     "fire_grapple": 0x228ee,
     "G_Damage": 0x20074,
     "G_InitGame": 0x2b7,


### PR DESCRIPTION
I almost lost hope for a second, and thought I had to reverse all of `ClientSpawn` or pull up with an ugly trampoline. Thank cgg for this function.

Do you remember the pendulum map, so I can test that too? riwa something?